### PR TITLE
Fix scores for single-row dataset

### DIFF
--- a/aif360/datasets/binary_label_dataset.py
+++ b/aif360/datasets/binary_label_dataset.py
@@ -30,7 +30,7 @@ class BinaryLabelDataset(StructuredDataset):
         """
         # fix scores before validating
         if np.all(self.scores == self.labels):
-            self.scores = np.float64(self.scores == self.favorable_label)
+            self.scores = (self.scores == self.favorable_label).astype(np.float64)
 
         super(BinaryLabelDataset, self).validate_dataset()
 


### PR DESCRIPTION
`np.float64(...)` squeezes the result so use `.astype(np.float64)` instead

Credit: Hugo Miralles on Slack for discovering this.