### PR TITLE
Reconcile code and docstring for consistency_score and consistency

### DIFF
--- a/aif360/metrics/binary_label_dataset_metric.py
+++ b/aif360/metrics/binary_label_dataset_metric.py
@@ -126,8 +126,8 @@ class BinaryLabelDatasetMetric(DatasetMetric):
         labels are for similar instances.
 
         .. math::
-           1 - \frac{1}{n\cdot\text{n_neighbors}}\sum_{i=1}^n |\hat{y}_i -
-           \sum_{j\in\mathcal{N}_{\text{n_neighbors}}(x_i)} \hat{y}_j|
+           1 - \frac{1}{n}\sum_{i=1}^n |\hat{y}_i -
+           \frac{1}{\text{n_neighbors}} \sum_{j\in\mathcal{N}_{\text{n_neighbors}}(x_i)} \hat{y}_j|
 
         Args:
             n_neighbors (int, optional): Number of neighbors for the knn

--- a/aif360/sklearn/metrics/metrics.py
+++ b/aif360/sklearn/metrics/metrics.py
@@ -554,8 +554,8 @@ def consistency_score(X, y, n_neighbors=5):
     labels are for similar instances.
 
     .. math::
-        1 - \frac{1}{n\cdot\text{n_neighbors}}\sum_{i=1}^n |\hat{y}_i -
-        \sum_{j\in\mathcal{N}_{\text{n_neighbors}}(x_i)} \hat{y}_j|
+        1 - \frac{1}{n}\sum_{i=1}^n |\hat{y}_i -
+        \frac{1}{\text{n_neighbors}} \sum_{j\in\mathcal{N}_{\text{n_neighbors}}(x_i)} \hat{y}_j|
 
     Args:
         X (array-like): Sample features.


### PR DESCRIPTION
The documentation for the functions consistency_score and consistency
match the paper, which has a factor of 1 over k (k=n_neighbors in the
AIF360 documentation) to the left of the outer sum, rather than to the
left of the inner sum. The code in both functions does not match the
documentation since it takes the mean of y for the k nearest neighbours
(rather than the sum) and doesn't divide the outer sum by n_neighbors.
    
To see the error in the previous documentation, consider the extreme
case where y_hat = 1 for all examples. Here the consistency_score should
be 1 as implemented in the code.