### PR TITLE
Update README.md

### DIFF
--- a/aif360/aif360-r/README.md
+++ b/aif360/aif360-r/README.md
@@ -116,6 +116,7 @@ restart.
     reticulate::use_miniconda(condaenv = "r-test", required = TRUE)
     load_aif360_lib()
 
+
 ## Getting Started
 
 ``` r


### PR DESCRIPTION
after performing steps mentioned until 3 in suggested steps then we need to do following steps before performing step-4
library(reticulate)
py_install('aif360')

This steps needs to be performed otherwise following error will be thrown:
Error in py_module_import(module, convert = convert) : 
  ModuleNotFoundError: No module named 'aif360'