### PR TITLE
Increasing max_iter to 1000 for LogisticRegression used in PrejudiceRemover

### DIFF
--- a/aif360/algorithms/inprocessing/kamfadm-2012ecmlpkdd/fadm/lr/pr.py
+++ b/aif360/algorithms/inprocessing/kamfadm-2012ecmlpkdd/fadm/lr/pr.py
@@ -236,7 +236,7 @@ class LRwPRFittingType1Mixin(LRwPR):
             coef = self.coef_.reshape(self.n_sfv_, self.n_features_)
 
             for i in range(self.n_sfv_):
-                clr = LogisticRegression(C=self.C, penalty='l2',
+                clr = LogisticRegression(C=self.C, penalty='l2', max_iter=1000,
                                          fit_intercept=False)
                 clr.fit(X[s == i, :], y[s == i])
                 coef[i, :] = clr.coef_

--- a/aif360/algorithms/inprocessing/prejudice_remover.py
+++ b/aif360/algorithms/inprocessing/prejudice_remover.py
@@ -27,6 +27,7 @@ Changes made to fairness-comparison code:
         - kamfadm-2012ecmlpkdd/train_nb.py
     * fixed typo in kamfadm-2012ecmlpkdd/fadm/lr/pr.py:244 (typeError -> TypeError)
     * removed commands.py and instead use subprocess.getoutput
+    * increased max_iter to 1000 in kamfadm-2012ecmlpkdd/fadm/lr/pr.py:239
 
 Notes from fairness-comparison's KamishimaAlgorithm.py on changes made to
 original Kamishima code.


### PR DESCRIPTION
The `PrejudiceRemover` inprocessing bias mitigation algorithm uses `LogisticRegression`, and by default, `max_iter` for `LogisticRegression` from sklearn is 100. However, in practice, more iterations are occasionally needed to fit `PrejudiceRemover` to large datasets, some of which are common benchmarks in the fairness literature.

With this in mind, this PR increases the `max_iter` threshold to 1000 from 100 in order to help `PrejudiceRemover` properly converge on large datasets.