### PR TITLE
Fix exponential gradient reduction without protected attribute (#267)

### DIFF
--- a/aif360/sklearn/inprocessing/exponentiated_gradient_reduction.py
+++ b/aif360/sklearn/inprocessing/exponentiated_gradient_reduction.py
@@ -144,6 +144,6 @@ class ExponentiatedGradientReduction(BaseEstimator, ClassifierMixin):
             ``self.classes_``.
         """
         if self.drop_prot_attr:
-            X = X.drop(self.prot_attr)
+            X = X.drop(self.prot_attr, axis=1)
 
         return self.model._pmf_predict(X)


### PR DESCRIPTION
Fixes #267.

* Exponential Gradient Reduction with `drop_prot_attr=True` lead to errors when calling `predict_proba`.
* This is due to the call `X.drop(self.prot_attr) in the function
* Should be `X.drop(self.prot_attr, axis=1)` to go over the dataframe's columns (cf. call in `predict`)
* This PR fixes exactly that