### PR TITLE
More flexibility for CalibratedEqualizedOdds

### DIFF
--- a/aif360/sklearn/postprocessing/__init__.py
+++ b/aif360/sklearn/postprocessing/__init__.py
@@ -127,9 +127,9 @@ class PostProcessingMeta(BaseEstimator, MetaEstimatorMixin):
         y_score = pd.DataFrame(y_score, index=X_post.index).squeeze('columns')
         fit_params = fit_params.copy()
         fit_params.update(labels=self.estimator_.classes_)
-        self.postprocessor_.fit(y_score, y_post, sample_weight=sw_post
-                                if sample_weight is not None else None,
-                                **fit_params)
+        if sample_weight is not None:
+            fit_params.update(sample_weight=sw_post)
+        self.postprocessor_.fit(y_score, y_post, **fit_params)
         return self
 
     @if_delegate_has_method('postprocessor_')
@@ -220,10 +220,9 @@ class PostProcessingMeta(BaseEstimator, MetaEstimatorMixin):
         y_score = (self.estimator_.predict_proba(X) if use_proba else
                    self.estimator_.predict(X))
         y_score = pd.DataFrame(y_score, index=X.index).squeeze('columns')
-        if sample_weight is None:
-            return self.postprocessor_.score(y_score, y)
-        return self.postprocessor_.score(y_score, y,
-                                         sample_weight=sample_weight)
+        score_params = ({} if sample_weight is None else
+                        {'sample_weight': sample_weight})
+        return self.postprocessor_.score(y_score, y, **score_params)
 
 
 __all__ = [

--- a/tests/sklearn/test_calibrated_equalized_odds.py
+++ b/tests/sklearn/test_calibrated_equalized_odds.py
@@ -19,6 +19,23 @@ def test_calib_eq_odds_priv_group():
         CalibratedEqualizedOdds('b').fit(y_pred, y)
     assert CalibratedEqualizedOdds('b').fit(y_pred, y, priv_group=0)
 
+def test_calib_eq_odds_pos_label(new_adult):
+    """Test the behavior of the `pos_label` option."""
+    X, y, sample_weight = new_adult
+    logreg = LogisticRegression(solver='lbfgs', max_iter=500)
+    y_pred = logreg.fit(X, y, sample_weight=sample_weight).predict_proba(X)
+    ceo = CalibratedEqualizedOdds('sex')
+    p0 = ceo.fit(y_pred, y, sample_weight=sample_weight, pos_label=0).mix_rates_
+    p1 = ceo.fit(y_pred, y, sample_weight=sample_weight, pos_label=1).mix_rates_
+    assert np.allclose(p0, p1)
+
+    ceo = CalibratedEqualizedOdds('sex', cost_constraint='fpr')
+    with pytest.raises(ValueError):
+        ceo.fit(y_pred, y, sample_weight=sample_weight)
+    p0 = ceo.fit(y_pred, y, sample_weight=sample_weight, pos_label=0).mix_rates_
+    p1 = ceo.fit(y_pred, y, sample_weight=sample_weight, pos_label=1).mix_rates_
+    assert not np.allclose(p0, p1)
+
 def test_calib_eq_odds_sex_weighted(old_adult, new_adult):
     """Test that the old and new CalibratedEqualizedOdds produce the same mix
     rates.

--- a/tests/sklearn/test_calibrated_equalized_odds.py
+++ b/tests/sklearn/test_calibrated_equalized_odds.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 import sklearn
 from sklearn.linear_model import LogisticRegression
@@ -7,6 +8,16 @@ from sklearn.model_selection import train_test_split
 from aif360.algorithms.postprocessing import CalibratedEqOddsPostprocessing
 from aif360.sklearn.postprocessing import CalibratedEqualizedOdds, PostProcessingMeta
 
+
+def test_calib_eq_odds_priv_group():
+    """Test the behavior of the `priv_group` option."""
+    y = pd.DataFrame([[0, 0, 0], [1, 1, 0], [0, 2, 1], [1, 0, 1]], columns=['a', 'b', 'y'])
+    y = y.set_index(['a', 'b']).squeeze()
+    y_pred = np.array([[0.5, 0.5], [0.3, 0.7], [0.8, 0.2], [0.1, 0.9]])
+    assert CalibratedEqualizedOdds('a').fit(y_pred, y).priv_group_ == 1
+    with pytest.raises(ValueError):
+        CalibratedEqualizedOdds('b').fit(y_pred, y)
+    assert CalibratedEqualizedOdds('b').fit(y_pred, y, priv_group=0)
 
 def test_calib_eq_odds_sex_weighted(old_adult, new_adult):
     """Test that the old and new CalibratedEqualizedOdds produce the same mix


### PR DESCRIPTION
* add `priv_group` option to binarize groups
* make `pos_label` implicit if constraint is `'weighted'`