### PR TITLE
Remove turtle module import

### DIFF
--- a/aif360/detectors/mdss/ScoringFunctions/Gaussian.py
+++ b/aif360/detectors/mdss/ScoringFunctions/Gaussian.py
@@ -1,4 +1,3 @@
-from turtle import pen
 from aif360.detectors.mdss.ScoringFunctions.ScoringFunction import ScoringFunction
 from aif360.detectors.mdss.ScoringFunctions import optim
 


### PR DESCRIPTION
### Changes
- Remove `turtle` module import, since it doesn't seem to be getting used and breaks aif360

Signed-off-by: Gaurav Kumbhat <kumbhat.gaurav@gmail.com>