### PR TITLE
Bank readme fix

### DIFF
--- a/aif360/data/raw/bank/README.md
+++ b/aif360/data/raw/bank/README.md
@@ -12,7 +12,7 @@ Additional information on dataset and features is available in `bank-additional-
 
 1. Download the file [bank-additional.zip](https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip).
 
-2. Extract files from the downloaded archive and place the files 'bank-additional.csv' and 'bank-additional-names.txt' into the current folder.
+2. Extract files from the downloaded archive and place the files 'bank-additional-full.csv' and 'bank-additional-names.txt' into the current folder.
 
 ## Relevant Papers
 

--- a/aif360/data/raw/bank/README.md
+++ b/aif360/data/raw/bank/README.md
@@ -12,7 +12,7 @@ Additional information on dataset and features is available in `bank-additional-
 
 1. Download the file [bank-additional.zip](https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip).
 
-2. Extract files from the downloaded archive and place the files 'bank-additional-full.csv' and 'bank-additional-names.txt' into the current folder.
+2. Extract all files from the downloaded archive and place them, as-is, in the current folder.
 
 ## Relevant Papers
 


### PR DESCRIPTION
Currently, the bank dataset IOError() and bank dataset README have conflicting content.

The error message asks you to download the zip file and keep all included files:
```
IOError: [Errno 2] No such file or directory: '/home/korbinian/.local/lib/python3.10/site-packages/aif360/datasets/../data/raw/bank/bank-additional-full.csv'
To use this class, please download the following file:

	https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip

unzip it and place the files, as-is, in the folder:

	/home/korbinian/.local/lib/python3.10/site-packages/aif360/data/raw/bank
```

The README asks you to download the zip and only keep the files `bank-additional.csv` and `bank-additional-names.txt`. The file actually needed to load the dataset is `bank-additional-full.csv`.

Solution proposal A):
Change README.md to match error message (done in this PR).

Solution proposal B):
Change both README.md and error message to only keep 'bank-additional-full.csv' and 'bank-additional-names.txt'.

Please decide which solution you prefer. I'll be happy to modify this pull request accordingly.

Signed-off-by: Korbinian Koch <korbinian-koch@web.de>