### PR TITLE
Fix typo in GridSearchReduction

### DIFF
--- a/aif360/algorithms/inprocessing/grid_search_reduction.py
+++ b/aif360/algorithms/inprocessing/grid_search_reduction.py
@@ -137,7 +137,7 @@ class GridSearchReduction(Transformer):
         dataset_new = dataset.copy()
         dataset_new.labels = self.model.predict(X_df).reshape(-1, 1)
 
-        if isinstance(self.model.moment, red.ClassificationMoment):
+        if isinstance(self.model.moment_, red.ClassificationMoment):
             fav = int(dataset.favorable_label)
             try:
                 # Probability of favorable label


### PR DESCRIPTION
Linked to issue #451 

The previous version of predict() in [GridSearchReduction](https://github.com/Trusted-AI/AIF360/blob/master/aif360/algorithms/inprocessing/grid_search_reduction.py) had a typo where it tried to call `self.model.moment` to check which ClassificationMoment the model uses. 

This should be `self.model.moment_` in accordance with the sklearn-compatible version of [GridSearchReduction](https://github.com/Trusted-AI/AIF360/blob/master/aif360/sklearn/inprocessing/grid_search_reduction.py). 