### PR TITLE
Small fix for issue #422, currently throws `AttributeError`

### DIFF
--- a/aif360/sklearn/preprocessing/learning_fair_representations.py
+++ b/aif360/sklearn/preprocessing/learning_fair_representations.py
@@ -164,7 +164,7 @@ class LearnedFairRepresentations(BaseEstimator, ClassifierMixin, TransformerMixi
                           'iterations.', ConvergenceWarning)
         elif res.status == 2:
             warnings.warn('lbfgs failed to converge: {}'.format(
-                          res.message.decode()), ConvergenceWarning)
+                          res.message), ConvergenceWarning)
         return self
 
     def transform(self, X):


### PR DESCRIPTION
This is a one-line fix for issue #422 (see the issue for a reproducible example).

Essentially, aif360 tries to call `decode()` on a `str` object which throws an `AttributeError`.

The `OptimizeResult` object is detailed [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html#scipy.optimize.OptimizeResult), and clearly states that its `message` attribute is of type `str`.