### PR TITLE
Fix tests failing due to int columns

### DIFF
--- a/aif360/sklearn/preprocessing/learning_fair_representations.py
+++ b/aif360/sklearn/preprocessing/learning_fair_representations.py
@@ -149,7 +149,7 @@ class LearnedFairRepresentations(BaseEstimator, ClassifierMixin, TransformerMixi
         x0 = rng.random(w_size + self.n_prototypes*n_feat)
         bounds = [(0, 1)]*w_size + [(None, None)]*self.n_prototypes*n_feat
         res = optim.minimize(LFR_optim_objective, x0=x0, method='L-BFGS-B',
-                args=(torch.tensor(X.to_numpy()), torch.as_tensor(y), priv),
+                args=(torch.tensor(X.to_numpy(dtype=x0.dtype)), torch.as_tensor(y), priv),
                 jac=True, bounds=bounds, options={'gtol': self.tol,
                 'maxiter': self.max_iter})
 

--- a/aif360/sklearn/preprocessing/reweighing.py
+++ b/aif360/sklearn/preprocessing/reweighing.py
@@ -73,7 +73,7 @@ class Reweighing(BaseEstimator):
         """
         X, y, sample_weight = check_inputs(X, y, sample_weight)
 
-        sample_weight_t = np.empty_like(sample_weight)
+        sample_weight_t = np.empty_like(sample_weight, dtype=float)
         groups, self.prot_attr_ = check_groups(X, self.prot_attr)
         # TODO: maintain categorical ordering
         self.groups_ = np.unique(groups)
@@ -88,7 +88,7 @@ class Reweighing(BaseEstimator):
             for j, c in enumerate(self.classes_):
                 g_and_c = (groups == g) & (y == c)
                 if np.any(g_and_c):
-                    W_gc = N_(groups == g) * N_(y == c) / (N * N_(g_and_c))
+                    W_gc = N_(groups == g) / N * N_(y == c) / N_(g_and_c)
                     sample_weight_t[g_and_c] = W_gc * sample_weight[g_and_c]
                     self.reweigh_factors_[i, j] = W_gc
         return X, sample_weight_t

--- a/examples/sklearn/demo_exponentiated_gradient_reduction_sklearn.ipynb
+++ b/examples/sklearn/demo_exponentiated_gradient_reduction_sklearn.ipynb
@@ -593,7 +593,7 @@
    ],
    "source": [
     "ohe = make_column_transformer(\n",
-    "        (OneHotEncoder(sparse=False), X_train.dtypes == 'category'),\n",
+    "        (OneHotEncoder(sparse_output=False), X_train.dtypes == 'category'),\n",
     "        remainder='passthrough', verbose_feature_names_out=False)\n",
     "X_train  = pd.DataFrame(ohe.fit_transform(X_train), columns=ohe.get_feature_names_out(), index=X_train.index)\n",
     "X_test = pd.DataFrame(ohe.transform(X_test), columns=ohe.get_feature_names_out(), index=X_test.index)\n",
@@ -784,8 +784,8 @@
    ],
    "source": [
     "np.random.seed(0) #for reproducibility\n",
-    "exp_grad_red = ExponentiatedGradientReduction(prot_attr=prot_attr_cols, \n",
-    "                                              estimator=estimator, \n",
+    "exp_grad_red = ExponentiatedGradientReduction(prot_attr=prot_attr_cols,\n",
+    "                                              estimator=estimator,\n",
     "                                              constraints=\"EqualizedOdds\",\n",
     "                                              drop_prot_attr=False)\n",
     "exp_grad_red.fit(X_train, y_train)\n",
@@ -916,11 +916,11 @@
     }
    ],
    "source": [
-    "import fairlearn.reductions as red \n",
+    "import fairlearn.reductions as red\n",
     "\n",
     "np.random.seed(0) #need for reproducibility\n",
-    "exp_grad_red2 = ExponentiatedGradientReduction(prot_attr=prot_attr_cols, \n",
-    "                                               estimator=estimator, \n",
+    "exp_grad_red2 = ExponentiatedGradientReduction(prot_attr=prot_attr_cols,\n",
+    "                                               estimator=estimator,\n",
     "                                               constraints=red.EqualizedOdds(),\n",
     "                                               drop_prot_attr=False)\n",
     "exp_grad_red2.fit(X_train, y_train)\n",

--- a/tests/sklearn/test_datasets.py
+++ b/tests/sklearn/test_datasets.py
@@ -177,7 +177,7 @@ def test_german_matches_old():
     old = old.apply(lambda c: c.factorize()[0] if not is_numeric_dtype(c) else c)
 
     assert_frame_equal(X.reset_index(drop=True), old.reset_index(drop=True),
-                       check_like=True)
+                       check_like=True, check_dtype=False)
 
 def test_fetch_bank():
     """Tests Bank Marketing dataset shapes with various options."""


### PR DESCRIPTION
Some dtypes changed which caused mismatches and overflow. Also fixed deprecated `sparse` option -> `sparse_output`.