### PR TITLE
Fixed Example Google Style Python Docstrings URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,5 @@ To generate the documentation, run `make` from the `docs/` directory.
 
 ## Style
 This project uses Google-style docstrings. See:
-[http://www.sphinx-doc.org/en/1.5/ext/example_google.html
+[https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html
 ](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html)for more details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,5 @@ To generate the documentation, run `make` from the `docs/` directory.
 
 ## Style
 This project uses Google-style docstrings. See:
-http://www.sphinx-doc.org/en/1.5/ext/example_google.html
-for more details.
+[http://www.sphinx-doc.org/en/1.5/ext/example_google.html
+](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html)https://www.sphinx-doc.org/en/master/usage/extensions/example_google.htmlfor more details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@ To generate the documentation, run `make` from the `docs/` directory.
 ## Style
 This project uses Google-style docstrings. See:
 [http://www.sphinx-doc.org/en/1.5/ext/example_google.html
-](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html)https://www.sphinx-doc.org/en/master/usage/extensions/example_google.htmlfor more details.
+](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html)https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html for more details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@ To generate the documentation, run `make` from the `docs/` directory.
 ## Style
 This project uses Google-style docstrings. See:
 [http://www.sphinx-doc.org/en/1.5/ext/example_google.html
-](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html)https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html for more details.
+](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html)for more details.


### PR DESCRIPTION
The previous URL redirected users to a 404 page. I've updated the link to the correct one.

<img width="1417" alt="Screenshot 2024-03-20 at 10 41 13 AM" src="https://github.com/Trusted-AI/AIF360/assets/141953346/aab65a87-193c-477f-b181-44c327b34b3d">
