### PR TITLE
Fix OneHotEncoder usage in sklearn example notebook

### DIFF
--- a/examples/sklearn/demo_new_features.ipynb
+++ b/examples/sklearn/demo_new_features.ipynb
@@ -632,7 +632,7 @@
    ],
    "source": [
     "ohe = make_column_transformer(\n",
-    "        (OneHotEncoder(sparse=False), X_train.dtypes == 'category'),\n",
+    "        (OneHotEncoder(sparse_output=False), X_train.dtypes == 'category'),\n",
     "        remainder='passthrough', verbose_feature_names_out=False)\n",
     "X_train  = pd.DataFrame(ohe.fit_transform(X_train), columns=ohe.get_feature_names_out(), index=X_train.index)\n",
     "X_test = pd.DataFrame(ohe.transform(X_test), columns=ohe.get_feature_names_out(), index=X_test.index)\n",


### PR DESCRIPTION
Updated the `OneHotEncoder` usage in `examples/sklearn/demo_new_features.ipynb` to replace the deprecated `sparse` parameter with `sparse_output`. This resolves an error on Issue #529 during compilation due to recent updates in sklearn's API.