### PR TITLE
Fix docstring escape sequences for compatibility with Python 3.12

### DIFF
--- a/aif360/sklearn/inprocessing/infairness.py
+++ b/aif360/sklearn/inprocessing/infairness.py
@@ -253,7 +253,7 @@ class SenSeI(InFairnessNet):
     """
     def __init__(self, module, *, criterion, distance_x, distance_y, rho, eps,
                  auditor_nsteps, auditor_lr, regression='auto', **kwargs):
-        """
+        r"""
         Args:
             module (torch.nn.Module): Network architecture.
             criterion (torch.nn.Module): Loss function.
@@ -335,7 +335,7 @@ class SenSR(InFairnessNet):
     """
     def __init__(self, module, *, criterion, distance_x, eps, lr_lamb, lr_param,
                  auditor_nsteps, auditor_lr, regression='auto', **kwargs):
-        """
+        r"""
         Args:
             module (torch.nn.Module): Network architecture.
             criterion (torch.nn.Module): Loss function.


### PR DESCRIPTION
@hoffmansc 

This PR handles 'r' missing docstrings to remove Syntax warnings mentioned in https://github.com/Trusted-AI/AIF360/issues/536.
I've checked for missing 'r' prefixes in docstrings, and this is the complete list of those that were missing.