### PR TITLE
Make notebooks in examples run out of the box using Binder (4/5)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,14 @@ features of the new `scikit-learn`-compatible API
 
 [demo_optim_data_preproc.ipynb](demo_optim_data_preproc.ipynb): demonstrates a generalization of the credit scoring tutorial that  shows the full machine learning workflow for the optimized data pre-processing algorithm for bias mitigation on several datasets
 
+[demo_optim_preproc_adult.ipynb](demo_optim_preproc_adult.ipynb): demonstrates the use of the optimized pre-processing algorithm for bias mitigation on the Adult dataset
+
+[demo_reject_option_classification.ipynb](demo_reject_option_classification.ipynb): demonstrates the use of the Reject Option Classification (ROC) post-processing algorithm for bias mitigation
+
+[demo_reweighing_preproc.ipynb](demo_reweighing_preproc.ipynb):  demonstrates the use of a reweighing pre-processing algorithm for bias mitigation
+
+[demo_short_gerryfair_test.ipynb](demo_short_gerryfair_test.ipynb): demonstrates the use of the GerryFairClassifier in-processing algorithm for bias mitigation
+
 [demo_adversarial_debiasing.ipynb](demo_adversarial_debiasing.ipynb): demonstrates the use of the adversarial debiasing in-processing algorithm to learn a fair classifier
 
 [demo_calibrated_eqodds_postprocessing.ipynb](demo_calibrated_eqodds_postprocessing.ipynb): demonstrates the use of an odds-equalizing post-processing algorithm for bias mitigiation
@@ -29,7 +37,3 @@ features of the new `scikit-learn`-compatible API
 [demo_lfr.ipynb](demo_lfr.ipynb):  demonstrates the use of the learning fair representations algorithm for bias mitigation
 
 [demo_lime.ipynb](demo_lime.ipynb):  demonstrates how LIME - Local Interpretable Model-Agnostic Explanations - can be used with models learned with the AIF 360 toolkit to generate explanations for model predictions
-
-[demo_reject_option_classification.ipynb](demo_reject_option_classification.ipynb): demonstrates the use of the Reject Option Classification (ROC) post-processing algorithm for bias mitigation
-
-[demo_reweighing_preproc.ipynb](demo_reweighing_preproc.ipynb):  demonstrates the use of a reweighing pre-processing algorithm for bias mitigation

--- a/examples/demo_optim_preproc_adult.ipynb
+++ b/examples/demo_optim_preproc_adult.ipynb
@@ -57,6 +57,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import aif360\n",
+    "\n",
+    "# Obtain the location where it is installed\n",
+    "LIB_PATH = aif360.__file__.rsplit('aif360', 1)[0]\n",
+    "\n",
+    "# Download Adult dataset files if they are not already present.\n",
+    "adult_data_path = os.path.join(LIB_PATH, 'aif360', 'data', 'raw', 'adult')\n",
+    "adult_data_url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/adult/'\n",
+    "adult_files = ['adult.data', 'adult.test', 'adult.names']\n",
+    "os.makedirs(adult_data_path, exist_ok=True)\n",
+    "for adult_file in adult_files:\n",
+    "    adult_file_path = os.path.join(adult_data_path, adult_file)\n",
+    "    if not os.path.exists(adult_file_path):\n",
+    "        urllib.request.urlretrieve(adult_data_url + adult_file, adult_file_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/examples/demo_reject_option_classification.ipynb
+++ b/examples/demo_reject_option_classification.ipynb
@@ -20,6 +20,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import aif360\n",
+    "\n",
+    "# Obtain the location where it is installed\n",
+    "LIB_PATH = aif360.__file__.rsplit('aif360', 1)[0]\n",
+    "\n",
+    "# Download Adult dataset files if they are not already present.\n",
+    "adult_data_path = os.path.join(LIB_PATH, 'aif360', 'data', 'raw', 'adult')\n",
+    "adult_data_url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/adult/'\n",
+    "adult_files = ['adult.data', 'adult.test', 'adult.names']\n",
+    "os.makedirs(adult_data_path, exist_ok=True)\n",
+    "for adult_file in adult_files:\n",
+    "    adult_file_path = os.path.join(adult_data_path, adult_file)\n",
+    "    if not os.path.exists(adult_file_path):\n",
+    "        urllib.request.urlretrieve(adult_data_url + adult_file, adult_file_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/examples/demo_reweighing_preproc.ipynb
+++ b/examples/demo_reweighing_preproc.ipynb
@@ -9,6 +9,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import aif360\n",
+    "\n",
+    "# Obtain the location where it is installed\n",
+    "LIB_PATH = aif360.__file__.rsplit('aif360', 1)[0]\n",
+    "\n",
+    "# Download Adult dataset files if they are not already present.\n",
+    "adult_data_path = os.path.join(LIB_PATH, 'aif360', 'data', 'raw', 'adult')\n",
+    "adult_data_url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/adult/'\n",
+    "adult_files = ['adult.data', 'adult.test', 'adult.names']\n",
+    "os.makedirs(adult_data_path, exist_ok=True)\n",
+    "for adult_file in adult_files:\n",
+    "    adult_file_path = os.path.join(adult_data_path, adult_file)\n",
+    "    if not os.path.exists(adult_file_path):\n",
+    "        urllib.request.urlretrieve(adult_data_url + adult_file, adult_file_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/examples/demo_short_gerryfair_test.ipynb
+++ b/examples/demo_short_gerryfair_test.ipynb
@@ -2,6 +2,30 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib\n",
+    "import aif360\n",
+    "\n",
+    "# Obtain the location where it is installed\n",
+    "LIB_PATH = aif360.__file__.rsplit('aif360', 1)[0]\n",
+    "\n",
+    "# Download Adult dataset files if they are not already present.\n",
+    "adult_data_path = os.path.join(LIB_PATH, 'aif360', 'data', 'raw', 'adult')\n",
+    "adult_data_url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/adult/'\n",
+    "adult_files = ['adult.data', 'adult.test', 'adult.names']\n",
+    "os.makedirs(adult_data_path, exist_ok=True)\n",
+    "for adult_file in adult_files:\n",
+    "    adult_file_path = os.path.join(adult_data_path, adult_file)\n",
+    "    if not os.path.exists(adult_file_path):\n",
+    "        urllib.request.urlretrieve(adult_data_url + adult_file, adult_file_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "pycharm": {


### PR DESCRIPTION
## Summary
- Add Adult dataset download setup to the four Binder-targeted demo notebooks
- Update `examples/README.md` to include all four affected demos

## Related issue
Resolves #393
