### PR TITLE
Clarify average odds cancellation in metric explanations

### DIFF
--- a/aif360/explainers/metric_json_explainer.py
+++ b/aif360/explainers/metric_json_explainer.py
@@ -64,7 +64,9 @@ class MetricJSONExplainer(MetricTextExplainer):
             ("numTruePositivesPrivileged", self.metric.num_true_positives(privileged=True)),
             ("numPositivesPrivileged", self.metric.num_positives(privileged=True)),
             ("description", "Computed as average difference of false positive rate (false positives / negatives) and true positive rate (true positives / positives) between unprivileged and privileged groups."),
-            ("ideal", "The ideal value of this metric is 0.  A value of < 0 implies higher benefit for the privileged group and a value > 0 implies higher benefit for the unprivileged group.")
+            ("ideal", "Equality of odds implies a value of 0, but opposite-signed "
+                "FPR and TPR differences can cancel. A value of 0 alone does "
+                "not imply equality of odds.")
         ))
         return json.dumps(response)
 

--- a/aif360/explainers/metric_text_explainer.py
+++ b/aif360/explainers/metric_text_explainer.py
@@ -40,7 +40,7 @@ class MetricTextExplainer(Explainer):
 
     def average_odds_difference(self):
         return ("Average odds difference (average of TPR difference and FPR "
-                "difference, 0 = equality of odds): {}".format(
+                "difference, 0 does not imply equality of odds): {}".format(
                     self.metric.average_odds_difference()))
 
     def between_all_groups_coefficient_of_variation(self):

--- a/aif360/metrics/classification_metric.py
+++ b/aif360/metrics/classification_metric.py
@@ -552,7 +552,10 @@ class ClassificationMetric(BinaryLabelDatasetMetric):
            \tfrac{1}{2}\left[(FPR_{D = \text{unprivileged}} - FPR_{D = \text{privileged}})
            + (TPR_{D = \text{unprivileged}} - TPR_{D = \text{privileged}}))\right]
 
-        A value of 0 indicates equality of odds.
+        Equality of odds implies a value of 0, but the converse is not true:
+        opposite-signed differences in FPR and TPR can cancel. Use
+        :meth:`average_abs_odds_difference` or :meth:`equalized_odds_difference`
+        to avoid this cancellation.
         """
         return 0.5 * (self.difference(self.false_positive_rate)
                     + self.difference(self.true_positive_rate))

--- a/aif360/sklearn/metrics/metrics.py
+++ b/aif360/sklearn/metrics/metrics.py
@@ -636,7 +636,7 @@ def equal_opportunity_difference(y_true, y_pred, *, prot_attr=None,
 
 def average_odds_difference(y_true, y_pred, *, prot_attr=None, priv_group=1,
                             pos_label=1, sample_weight=None):
-    r"""A relaxed version of equality of odds.
+    r"""Average signed difference in false positive and true positive rates.
 
     Returns the average of the difference in FPR and TPR for the unprivileged
     and privileged groups:
@@ -646,7 +646,9 @@ def average_odds_difference(y_true, y_pred, *, prot_attr=None, priv_group=1,
         \dfrac{(FPR_{D = \text{unprivileged}} - FPR_{D = \text{privileged}})
         + (TPR_{D = \text{unprivileged}} - TPR_{D = \text{privileged}})}{2}
 
-    A value of 0 indicates equality of odds.
+    Equality of odds implies a value of 0, but the converse is not true:
+    opposite-signed differences in FPR and TPR can cancel. Use
+    :func:`average_odds_error` to avoid this cancellation.
 
     Args:
         y_true (pandas.Series): Ground truth (correct) target values.

--- a/tests/test_average_odds_explanation.py
+++ b/tests/test_average_odds_explanation.py
@@ -1,0 +1,30 @@
+import json
+
+import pandas as pd
+
+from aif360.datasets import BinaryLabelDataset
+from aif360.explainers import MetricJSONExplainer, MetricTextExplainer
+from aif360.metrics import ClassificationMetric
+
+
+def test_average_odds_cancellation():
+    # Group 0 has TPR=0 and FPR=1; group 1 has TPR=1 and FPR=0.
+    # Their signed differences cancel, despite unequal odds.
+    data = BinaryLabelDataset(
+        df=pd.DataFrame({'group': [0, 0, 1, 1], 'label': [0, 1, 0, 1]}),
+        label_names=['label'], protected_attribute_names=['group'])
+    predicted = data.copy(deepcopy=True)
+    predicted.labels = 1 - data.labels
+    predicted.labels[2:] = data.labels[2:]
+    metric = ClassificationMetric(data, predicted,
+        unprivileged_groups=[{'group': 0}], privileged_groups=[{'group': 1}])
+
+    assert metric.average_odds_difference() == 0
+    assert metric.average_abs_odds_difference() == 1
+    assert metric.equalized_odds_difference() == 1
+
+    message = MetricTextExplainer(metric).average_odds_difference()
+    assert '0 does not imply equality of odds' in message
+    explanation = json.loads(MetricJSONExplainer(metric).average_odds_difference())
+    assert explanation['message'] == message
+    assert 'cancel' in explanation['ideal']


### PR DESCRIPTION
Fixes #528.

Opposite-signed FPR and TPR differences can cancel: a four-row example returns average odds difference 0 while both average absolute odds difference and equalized odds difference are 1. Correct the two API docstrings and the text/JSON explanations so zero is no longer presented as sufficient for equality of odds. Metric formulas are unchanged.

The new explanation regression fails before the change. Local validation on Python 3.11:

- 50 tests pass across the explanation regression, classification metrics, structured datasets, sample distortion, regression metrics, and sklearn metrics (using the Adult dataset).
- Flake8 critical-error checks pass on the five changed files.
- A focused Sphinx build of the affected APIs passes with warnings treated as errors. The full documentation site also builds; its 27 warnings match a build of the unmodified base.

The full optional-dependency Python/R suite has not been run locally. The GitHub Actions workflow is awaiting maintainer approval.